### PR TITLE
turn 'move_on_after' into an official component

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest flake8 kivy==2.2.1 asyncgui==0.6.0
+        python -m pip install pytest flake8 kivy==2.2.1 "asyncgui>=0.6,<0.7"
         python -m pip install .
     - name: Lint with flake8
       run: make style

--- a/examples/trio_move_on_after.py
+++ b/examples/trio_move_on_after.py
@@ -1,18 +1,6 @@
-'''
-Implementing :func:`trio.move_on_after()`.
-'''
-
 from kivy.app import App
 from kivy.uix.label import Label
 import asynckivy as ak
-
-
-def move_on_after(seconds: float):
-    '''
-    Similar to :func:`trio.move_on_after`.
-    The difference is this one returns an async context manager not a regular one.
-    '''
-    return ak.wait_any_cm(ak.sleep(seconds))
 
 
 class TestApp(App):
@@ -26,7 +14,7 @@ class TestApp(App):
     async def main(self):
         label = self.root
         await ak.n_frames(2)
-        async with move_on_after(3):
+        async with ak.move_on_after(3):
             while True:
                 label.text = 'A'
                 await ak.sleep(.4)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asynckivy"
-version = "0.6.0"
+version = "0.6.1.dev0"
 description = "Async library for Kivy"
 authors = ["Nattōsai Mitō <flow4re2c@gmail.com>"]
 license = "MIT"

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -52,7 +52,7 @@ todo_include_todos = True
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'kivy': ('https://kivy.org/doc/master', None),
-    # 'trio': ('https://trio.readthedocs.io/en/stable/', None),
+    'trio': ('https://trio.readthedocs.io/en/stable/', None),
     # 'trio_util': ('https://trio-util.readthedocs.io/en/latest/', None),
     'asyncgui': ('https://gottadiveintopython.github.io/asyncgui/', None),
 }

--- a/src/asynckivy/__init__.py
+++ b/src/asynckivy/__init__.py
@@ -5,6 +5,7 @@ __all__ = (
     'event',
     'fade_transition',
     'interpolate',
+    'move_on_after',
     'n_frames',
     'repeat_sleeping',
     'rest_of_touch_events',
@@ -20,7 +21,7 @@ __all__ = (
 
 from asyncgui import *
 from ._exceptions import MotionEventAlreadyEndedError
-from ._sleep import sleep, sleep_free, repeat_sleeping
+from ._sleep import sleep, sleep_free, repeat_sleeping, move_on_after
 from ._event import event
 from ._animation import animate
 from ._interpolate import interpolate, fade_transition

--- a/src/asynckivy/_sleep.py
+++ b/src/asynckivy/_sleep.py
@@ -1,11 +1,11 @@
-__all__ = ('sleep', 'sleep_free', 'repeat_sleeping', )
+__all__ = ('sleep', 'sleep_free', 'repeat_sleeping', 'move_on_after', )
 
 import typing as T
 import types
 from functools import partial
 
 from kivy.clock import Clock
-from asyncgui import current_task, Cancelled, _sleep_forever
+from asyncgui import current_task, Cancelled, _sleep_forever, wait_any_cm
 
 
 @types.coroutine
@@ -128,3 +128,20 @@ def _efficient_sleep_ver_flexible(f):
     except Cancelled:
         f.cancel()
         raise
+
+
+def move_on_after(seconds: float):
+    '''
+    Similar to :func:`trio.move_on_after`.
+    The difference is this one returns an async context manager not a regular one.
+
+    .. code-block::
+
+        async with move_on_after(seconds) as bg_task:
+            ...
+        if bg_task.finished:
+            print("Timeout")
+        else:
+            print("with-block completed.")
+    '''
+    return wait_any_cm(sleep(seconds))


### PR DESCRIPTION
一使用例に過ぎなかった `move_on_after()` をモジュールの一部に昇格