### PR TITLE
make 'transform()' provide a CanvasBase instead of an InstructionGroup

### DIFF
--- a/examples/making_your_own_button.py
+++ b/examples/making_your_own_button.py
@@ -105,8 +105,8 @@ class CustomButton(Label):
                 inside = collide_point(*touch.pos)
                 if inside:
                     async with ak.disable_cancellation():
-                        with ak.transform(self, use_outer_canvas=True) as ig:
-                            ig.add(scale := Scale(origin=self.center))
+                        with ak.transform(self, use_outer_canvas=True) as group:
+                            group.add(scale := Scale(origin=self.center))
                             async for v in ak.interpolate(start=-0.1, end=0.1, duration=0.1):
                                 scale.x = scale.y = abs_(v) + 0.9
                 self.dispatch('on_release', inside)

--- a/examples/moving_a_sprite_along_with_a_bezier_curve.py
+++ b/examples/moving_a_sprite_along_with_a_bezier_curve.py
@@ -125,10 +125,10 @@ def generate_random_2d_points(*, n_points, min_x, min_y, max_x, max_y) -> T.Sequ
 def calc_factors(control_points):
     #
     # P(t) = (p0) +
-    #        t(-3p0 + 3p1) + 
+    #        t(-3p0 + 3p1) +
     #        t2(3p0 - 6p1 + 3p2) +
     #        t3(-p0 + 3p1 - 3p2 + p3)
-    # 
+    #
     p0, p1, p2, p3 = control_points
     return (
         p0,

--- a/examples/painter3.py
+++ b/examples/painter3.py
@@ -28,7 +28,8 @@ class Painter(RelativeLayout):
             _ud_key = self._ud_key
             nursery_start = nursery.start
             draw_rect = self.draw_rect
-            touch_down_event = partial(ak.event, self, 'on_touch_down', filter=self.accepts_touch, stop_dispatching=True)
+            touch_down_event = partial(
+                ak.event, self, 'on_touch_down', filter=self.accepts_touch, stop_dispatching=True)
 
             while True:
                 __, touch = await touch_down_event()

--- a/examples/popping_widget.py
+++ b/examples/popping_widget.py
@@ -21,11 +21,10 @@ degrees_per_second = float
 
 
 async def pop_widget(widget, *, height=300., duration=1., rotation_speed: degrees_per_second=360., ignore_touch=False):
-    with ignore_touch_down(widget) if ignore_touch else nullcontext(), transform(widget) as ig:  # <- InstructionGroup
-        translate = Translate()
-        rotate = Rotate(origin=widget.center)
-        ig.add(translate)
-        ig.add(rotate)
+    with ignore_touch_down(widget) if ignore_touch else nullcontext(), transform(widget) as group:
+        with group:
+            translate = Translate()
+            rotate = Rotate(origin=widget.center)
         async for dt, et, p in vanim.delta_time_elapsed_time_progress(duration=duration):
             p = p * 2. - 1.  # convert range[0 to +1] into range[-1 to +1]
             translate.y = (-(p * p) + 1.) * height

--- a/tests/test_utils_transform.py
+++ b/tests/test_utils_transform.py
@@ -34,7 +34,7 @@ def test_use_outer_canvas(widget, has_before, has_after):
         assert c.has_before
         assert c.has_after
         assert list_children(c) == ['CanvasBase', 'Color', 'CanvasBase']
-        assert list_children(c.before) == ['PushMatrix', 'InstructionGroup', ]
+        assert list_children(c.before) == ['PushMatrix', 'CanvasBase', ]
         assert list_children(c.after) == ['PopMatrix', ]
     assert list_children(c) == ['CanvasBase', 'Color', 'CanvasBase', ]
     assert list_children(c.before) == []
@@ -50,7 +50,7 @@ def test_use_inner_canvas__has_after(widget, has_before):
     with transform(widget, use_outer_canvas=False):
         assert c.has_before
         assert c.has_after
-        assert list_children(c) == ['CanvasBase', 'PushMatrix', 'InstructionGroup', 'Color', 'PopMatrix', 'CanvasBase', ]
+        assert list_children(c) == ['CanvasBase', 'PushMatrix', 'CanvasBase', 'Color', 'PopMatrix', 'CanvasBase', ]
         assert list_children(c.before) == []
         assert list_children(c.after) == []
     assert list_children(c) == ['CanvasBase', 'Color', 'CanvasBase', ]
@@ -66,7 +66,7 @@ def test_use_inner_canvas__no_after(widget, has_before):
     with transform(widget, use_outer_canvas=False):
         assert c.has_before
         assert not c.has_after
-        assert list_children(c) == ['CanvasBase', 'PushMatrix', 'InstructionGroup', 'Color', 'PopMatrix', ]
+        assert list_children(c) == ['CanvasBase', 'PushMatrix', 'CanvasBase', 'Color', 'PopMatrix', ]
         assert list_children(c.before) == []
     assert not c.has_after
     assert list_children(c) == ['CanvasBase', 'Color', ]


### PR DESCRIPTION
Unlike `InstructionGroup`, `CanvasBase` can be used as a context manager.