### PR TITLE
re-implement `rest_of_touch_events`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -13,13 +13,13 @@ files = [
 
 [[package]]
 name = "asyncgui"
-version = "0.7.1"
+version = "0.7.2"
 description = "A minimalistic async library that focuses on fast responsiveness"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "asyncgui-0.7.1-py3-none-any.whl", hash = "sha256:4ffa451b60455153e11a214db6bad9d4ae719fa810499f491b0fd25f65252eee"},
-    {file = "asyncgui-0.7.1.tar.gz", hash = "sha256:d339f0c9ebc824c8c92c1878d833624b19b4cca3c1ea7039056225374f823a5b"},
+    {file = "asyncgui-0.7.2-py3-none-any.whl", hash = "sha256:d3de7d96c94c7721809710ecdec6ac216ff8cf8b64c9ca8128a48c3564b50530"},
+    {file = "asyncgui-0.7.2.tar.gz", hash = "sha256:b9561434f2b73540706517dfe74bfde9d7f5ac537aad36f7fb8ebbbf92506800"},
 ]
 
 [package.dependencies]
@@ -403,7 +403,6 @@ files = [
     {file = "kivy_deps.angle-0.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:574381d4e66f3198bc48aa10f238e7a3816ad56b80ec939f5d56fb33a378d0b1"},
     {file = "kivy_deps.angle-0.4.0-cp312-cp312-win32.whl", hash = "sha256:4fa7a6366899fba13f7624baf4645787165f45731db08d14557da29c12ee48f0"},
     {file = "kivy_deps.angle-0.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:668e670d4afd2551af0af2c627ceb0feac884bd799fb6a3dff78fdbfa2ea0451"},
-    {file = "kivy_deps.angle-0.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:9afbf702f8bb9a993c48f39c018ca3b4d2ec381a5d3f82fe65bdaa6af0bba29b"},
     {file = "kivy_deps.angle-0.4.0-cp37-cp37m-win32.whl", hash = "sha256:24cfc0076d558080a00c443c7117311b4a977c1916fe297232eff1fd6f62651e"},
     {file = "kivy_deps.angle-0.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:48592ac6f7c183c5cd10d9ebe43d4148d0b2b9e400a2b0bcb5d21014cc929ce2"},
     {file = "kivy_deps.angle-0.4.0-cp38-cp38-win32.whl", hash = "sha256:1bbacf20bf6bd6ee965388f95d937c8fba2c54916fb44faa166c2ba58276753c"},
@@ -423,9 +422,6 @@ files = [
     {file = "kivy_deps.glew-0.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:aef2d2a93f129d8425c75234e7f6cc0a34b59a4aee67f6d2cd7a5fdfa9915b53"},
     {file = "kivy_deps.glew-0.3.1-cp311-cp311-win32.whl", hash = "sha256:ee2f80ef7ac70f4b61c50da8101b024308a8c59a57f7f25a6e09762b6c48f942"},
     {file = "kivy_deps.glew-0.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:22e155ec59ce717387f5d8804811206d200a023ba3d0bc9bbf1393ee28d0053e"},
-    {file = "kivy_deps.glew-0.3.1-cp312-cp312-win32.whl", hash = "sha256:b64ee4e445a04bc7c848c0261a6045fc2f0944cc05d7f953e3860b49f2703424"},
-    {file = "kivy_deps.glew-0.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:3acbbd30da05fc10c185b5d4bb75fbbc882a6ef2192963050c1c94d60a6e795a"},
-    {file = "kivy_deps.glew-0.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:f4aa8322078359862ccd9e16e5cea61976d75fb43125d87922e20c916fa31a11"},
     {file = "kivy_deps.glew-0.3.1-cp37-cp37m-win32.whl", hash = "sha256:5bf6a63fe9cc4fe7bbf280ec267ec8c47914020a1175fb22152525ff1837b436"},
     {file = "kivy_deps.glew-0.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:d64a8625799fab7a7efeb3661ef8779a7f9c6d80da53eed87a956320f55530fa"},
     {file = "kivy_deps.glew-0.3.1-cp38-cp38-win32.whl", hash = "sha256:00f4ae0a4682d951266458ddb639451edb24baa54a35215dce889209daf19a06"},
@@ -1018,4 +1014,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3257ee8d2cfa341009ee73e53360aa68ade222e9c96e3647f13a759595e49102"
+content-hash = "64368d58346e2deeba2314b0bda6d037ed97f39e2113f6bf2394d233da577e77"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-asyncgui = "~0.7"
+asyncgui = ">=0.7.2,<0.9"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0.1"

--- a/src/asynckivy/_touch.py
+++ b/src/asynckivy/_touch.py
@@ -3,10 +3,12 @@ __all__ = ('watch_touch', 'rest_of_touch_events', )
 import typing as T
 import types
 from functools import partial
-from asyncgui import wait_any, current_task
+from contextlib import nullcontext
+from asyncgui import wait_any, current_task, move_on_when
 from ._exceptions import MotionEventAlreadyEndedError
 from ._sleep import sleep
-from ._event import event
+from ._event import event, event_freq
+from ._utils import suppress_event
 
 
 class watch_touch:
@@ -124,8 +126,8 @@ class watch_touch:
 
 async def rest_of_touch_events(widget, touch, *, stop_dispatching=False, timeout=1.) -> T.AsyncIterator[None]:
     '''
-    Returns an async iterator that yields each occurrence of `on_touch_move`,
-    and stops when `on_touch_up` occurs.
+    Returns an async iterator that yields None on each ``on_touch_move`` event
+    and stops when an ``on_touch_up`` event occurs.
 
     .. code-block::
 
@@ -133,9 +135,42 @@ async def rest_of_touch_events(widget, touch, *, stop_dispatching=False, timeout
             print('on_touch_move')
         print('on_touch_up')
 
-    This is a wrapper around :class:`watch_touch`. While it may be more intuitive than :class:`watch_touch`,
-    it has a few drawbacks—see :ref:`the-problem-with-async-generators`.
+    **Caution**
+
+    * If the ``widget`` is the type of widget that grabs touches by itself, such as :class:`kivy.uix.button.Button`,
+      you probably want to set the ``stop_dispatching`` parameter to True in most cases.
+    * There are widgets/behaviors that might simulate touch events (e.g. :class:`kivy.uix.scrollview.ScrollView`,
+      :class:`kivy.uix.behaviors.DragBehavior` and ``kivy_garden.draggable.KXDraggableBehavior``).
+      If many such widgets are in the parent stack of the ``widget``, this API might mistakenly raise a
+      :exc:`asynckivy.MotionEventAlreadyEndedError`. If that happens, increase the ``timeout`` parameter.
     '''
-    async with watch_touch(widget, touch, stop_dispatching=stop_dispatching, timeout=timeout) as in_progress:
-        while await in_progress():
-            yield
+    if touch.time_end != -1:
+        # An `on_touch_up`` event might have already been fired, so we need to determine
+        # whether it actually was or not.
+        tasks = await wait_any(
+            sleep(timeout),
+            event(widget, 'on_touch_up', filter=lambda w, t: t is touch),
+        )
+        if tasks[0].finished:
+            raise MotionEventAlreadyEndedError(f"MotionEvent(uid={touch.uid}) has already ended")
+        return
+    try:
+        touch.grab(widget)
+        if stop_dispatching:
+            se = partial(suppress_event, widget,
+                         filter=lambda w, t, touch=touch: t is touch and t.grab_current is None)
+        with (
+            se("on_touch_up") if stop_dispatching else nullcontext(),
+            se("on_touch_move") if stop_dispatching else nullcontext(),
+        ):
+            def filter(w, t, touch=touch):
+                return t is touch and t.grab_current is w
+            async with (
+                move_on_when(event(widget, "on_touch_up", filter=filter, stop_dispatching=True)),
+                event_freq(widget, 'on_touch_move', filter=filter, stop_dispatching=True) as on_touch_move,
+            ):
+                while True:
+                    await on_touch_move()
+                    yield
+    finally:
+        touch.ungrab(widget)


### PR DESCRIPTION
This makes `rest_of_touch_events` no longer rely on `watch_touch`, allowing `watch_touch` to be removed in the future.