### PR TITLE
Add an option to make the effect of `sync_attr` and `sync_attrs` permanent

### DIFF
--- a/tests/test_utils_sync_attr.py
+++ b/tests/test_utils_sync_attr.py
@@ -7,7 +7,7 @@ def human_cls():
     from kivy.properties import NumericProperty
 
     class Human(EventDispatcher):
-        age = NumericProperty()
+        age = NumericProperty(10)
 
     return Human
 
@@ -23,6 +23,7 @@ def test_sync_attr(human):
 
     obj = types.SimpleNamespace()
     with ak.sync_attr(from_=(human, 'age'), to_=(obj, 'AGE')):
+        assert obj.AGE == 10
         human.age = 2
         assert obj.AGE == 2
         human.age = 0
@@ -37,6 +38,8 @@ def test_sync_attrs(human):
 
     obj = types.SimpleNamespace()
     with ak.sync_attrs((human, 'age'), (obj, 'AGE'), (obj, 'age')):
+        assert obj.AGE == 10
+        assert obj.age == 10
         human.age = 2
         assert obj.AGE == 2
         assert obj.age == 2


### PR DESCRIPTION
`sync_attr`と`sync_attrs`はこれまでcontext managerとしてしか使えなかったが、普通の函数としても使えるようにする。
context managerとして使った場合は効果はwith-blockが終わるまでの一時的なものだが、普通の函数として使えば`__exit()__`が自動では呼ばれなくなるため効果は永続的になる。

```python
# 効果はwith-blockが終わるまで
with sync_attr(...):
    ...

# 効果が永続
sync_attr(...)
```

加えて直ちに値の同期を行うようにもした。

```python
import types
w = Widget(x=0)
obj = types.SimpleNamespace()

with sync_attr((w, 'x'), (obj, 'xx')):
    # assert not hasattr(obj, 'xx')  # このPR前はこう
    assert w.x is obj.xx  # このPR後はこう
```