### PR TITLE
Add a new submodule: `transition`

### DIFF
--- a/examples/transition_showcase.py
+++ b/examples/transition_showcase.py
@@ -1,0 +1,104 @@
+'''
+https://youtu.be/qehA3oIMXZo
+'''
+from textwrap import dedent
+from functools import partial
+from contextlib import asynccontextmanager
+
+from kivy.utils import colormap
+from kivy.graphics import Scale, Rotate, Rectangle
+from kivy.core.window import Window
+from kivy.app import App
+from kivy.uix.label import Label
+
+import asynckivy as ak
+from asynckivy import transition as t
+
+
+# I didn't include this in the `transition` submodule because the implementation isn't very elegant.
+@asynccontextmanager
+async def scale_rotate_transition(target: t.Wow=Window, *, duration=1, out_curve='out_cubic', in_curve='in_cubic',
+                                  angle=360., use_outer_canvas=False):
+    with ak.transform(target, use_outer_canvas=use_outer_canvas) as ig:
+        center = target.center
+        ig.add(rotate := Rotate(origin=center))
+        ig.add(scale := Scale(origin=center))
+        half_d = duration / 2
+        half_angle = angle / 2
+        await ak.wait_all(
+            ak.anim_attrs_abbr(scale, d=half_d, t=out_curve, xyz=(0, 0, 1)),
+            ak.anim_attrs_abbr(rotate, d=half_d, angle=half_angle),
+        )
+        yield
+        await ak.wait_all(
+            ak.anim_attrs_abbr(scale, d=half_d, t=in_curve, xyz=(1, 1, 1)),
+            ak.anim_attrs_abbr(rotate, d=half_d, angle=angle),
+        )
+
+
+class TestApp(App):
+    def build(self):
+        return Label(font_size=64)
+
+    def on_start(self):
+        ak.managed_start(self.main())
+
+    async def main(self):
+        await ak.n_frames(4)
+        label = self.root
+        label.text = 'iris_transition'
+        touch_down = partial(ak.event, label, 'on_touch_down')
+        while True:
+            await touch_down()
+            async with t.iris_transition(duration=0.8, color=colormap['darkslategray']):
+                label.halign = 'center'
+                label.text = 'iris_transition\n\nwith a custom overlay'
+
+            await touch_down()
+            rect = Rectangle(size=Window.size, source='data/logo/kivy-icon-128.png')
+            texture = rect.texture
+            texture.wrap = 'repeat'
+            x_ratio = Window.width / texture.width
+            y_ratio = Window.height / texture.height
+            rect.tex_coords = (0, y_ratio, x_ratio, y_ratio, x_ratio, 0, 0, 0)
+            async with t.iris_transition(overlay=rect, out_curve='linear', in_curve='linear'):
+                await ak.sleep(.3)
+                label.text = 'slide_transition'
+                await ak.sleep(.3)
+
+            await touch_down()
+            async with t.slide_transition(duration=0.6):
+                label.halign = 'left'
+                label.text = dedent('''
+                    slide_transition(
+                        out_curve='in_back',
+                        in_curve='out_back',
+                    )''')
+
+            await touch_down()
+            async with t.slide_transition(duration=0.6, out_curve='in_back', in_curve='out_back'):
+                label.text = dedent('''
+                    slide_transition(
+                        x_direction='right',
+                        y_direction='up',
+                    )''')
+
+            await touch_down()
+            async with t.slide_transition(duration=0.6, x_direction='right', y_direction='up'):
+                label.text = 'scale_transition'
+
+            await touch_down()
+            async with t.scale_transition(duration=0.4):
+                label.text = 'scale_rotate_transition'
+
+            await touch_down()
+            async with scale_rotate_transition(duration=0.6):
+                label.text = 'fade_transition'
+
+            await touch_down()
+            async with t.fade_transition(duration=0.6):
+                label.text = 'iris_transition'
+
+
+if __name__ == '__main__':
+    TestApp(title='Transition Showcase').run()

--- a/roadmap.md
+++ b/roadmap.md
@@ -5,6 +5,7 @@
 
 # Eventually
 
+- `asynckivy.fade_transition` を `asynckivy.transition.fade_transition` に統合
 
 # Undetermind
 

--- a/src/asynckivy/_anim_attrs.py
+++ b/src/asynckivy/_anim_attrs.py
@@ -66,7 +66,7 @@ def _anim_attrs(
         clock_event.cancel()
 
 
-def anim_attrs(obj, *, duration=1, step=0, transition=AnimationTransition.linear, **animated_properties):
+def anim_attrs(obj, *, duration=1.0, step=0, transition=AnimationTransition.linear, **animated_properties):
     '''
     Animates attibutes of any object.
 
@@ -95,7 +95,7 @@ def anim_attrs(obj, *, duration=1, step=0, transition=AnimationTransition.linear
     return _anim_attrs(obj, duration, step, transition, animated_properties)
 
 
-def anim_attrs_abbr(obj, *, d=1, s=0, t=AnimationTransition.linear, **animated_properties):
+def anim_attrs_abbr(obj, *, d=1.0, s=0, t=AnimationTransition.linear, **animated_properties):
     '''
     :func:`anim_attrs` cannot animate attributes named ``step``, ``duration`` and ``transition`` but this one can.
 

--- a/src/asynckivy/_interpolate.py
+++ b/src/asynckivy/_interpolate.py
@@ -75,7 +75,7 @@ async def interpolate_seq(start, end, *, duration, step=0, transition=linear) ->
     zip_ = zip
     slope = tuple(end_elem - start_elem for end_elem, start_elem in zip_(end, start))
 
-    yield [transition(0) * slope_elem + start_elem for slope_elem, start_elem in zip_(slope, start)]
+    yield [transition(0.) * slope_elem + start_elem for slope_elem, start_elem in zip_(slope, start)]
 
     if duration:
         async for p in anim_with_ratio(step=step, base=duration):
@@ -85,7 +85,7 @@ async def interpolate_seq(start, end, *, duration, step=0, transition=linear) ->
     else:
         await sleep(0)
 
-    yield [transition(1) * slope_elem + start_elem for slope_elem, start_elem in zip_(slope, start)]
+    yield [transition(1.) * slope_elem + start_elem for slope_elem, start_elem in zip_(slope, start)]
 
 
 @asynccontextmanager

--- a/src/asynckivy/transition.py
+++ b/src/asynckivy/transition.py
@@ -1,0 +1,141 @@
+__all__ = (
+    'fade_transition', 'slide_transition', 'scale_transition', 'iris_transition',
+)
+
+from typing import Literal, Union
+from collections.abc import Sequence
+from contextlib import asynccontextmanager
+import math
+
+from kivy.utils import colormap
+from kivy.graphics import (
+    Translate, Scale, InstructionGroup, StencilPop, StencilPush, StencilUnUse, StencilUse,
+    Rectangle, Ellipse, Color, VertexInstruction
+)
+from kivy.animation import AnimationTransition
+from kivy.core.window import Window, WindowBase
+from kivy.uix.widget import Widget
+
+from asynckivy import anim_attrs_abbr, transform
+
+
+linear = AnimationTransition.linear
+Wow = Union[WindowBase, Widget]  # 'Wow' -> WindowBase or Widget
+
+
+@asynccontextmanager
+async def fade_transition(target: Wow=Window, *, duration=1, out_curve=linear, in_curve=linear):
+    '''
+    .. versionadded:: 0.9.0
+    '''
+    half_d = duration / 2
+    canvas = target.canvas
+    orig = canvas.opacity
+    try:
+        await anim_attrs_abbr(canvas, d=half_d, t=out_curve, opacity=0)
+        yield
+        await anim_attrs_abbr(canvas, d=half_d, t=in_curve, opacity=orig)
+    finally:
+        canvas.opacity = orig
+
+
+@asynccontextmanager
+async def slide_transition(target: Wow=Window, *, duration=1, out_curve='in_cubic', in_curve='out_cubic',
+                           x_direction: Literal['left', 'right', None]='left',
+                           y_direction: Literal['down', 'up', None]=None,
+                           use_outer_canvas=False):
+    '''
+    .. versionadded:: 0.9.0
+    '''
+    x_dist, y_dist = target.size
+    if x_direction is None:
+        x_dist = 0
+    elif x_direction == 'left':
+        x_dist = -x_dist
+    if y_direction is None:
+        y_dist = 0
+    elif y_direction == 'down':
+        y_dist = -y_dist
+
+    with transform(target, use_outer_canvas=use_outer_canvas) as ig:
+        ig.add(mat := Translate())
+        half_d = duration / 2
+        await anim_attrs_abbr(mat, d=half_d, t=out_curve, x=x_dist, y=y_dist)
+        yield
+        mat.x = -x_dist
+        mat.y = -y_dist
+        await anim_attrs_abbr(mat, d=half_d, t=in_curve, x=0, y=0)
+
+
+@asynccontextmanager
+async def scale_transition(target: Wow=Window, *, duration=1, out_curve='out_quad', in_curve='in_quad',
+                           use_outer_canvas=False):
+    '''
+    .. versionadded:: 0.9.0
+    '''
+    with transform(target, use_outer_canvas=use_outer_canvas) as ig:
+        ig.add(mat := Scale(origin=target.center))
+        half_d = duration / 2
+        await anim_attrs_abbr(mat, d=half_d, t=out_curve, xyz=(0, 0, 1))
+        yield
+        await anim_attrs_abbr(mat, d=half_d, t=in_curve, xyz=(1, 1, 1))
+
+
+def _calc_enclosing_circle_radius(circle_center, rectangle_size, max=max, hypot=math.hypot, abs=abs):
+    '''
+    Calculates the minimum radius required for a circle centered at the specified position to fully
+    enclose a rectangle of the given size, assuming its bottom-left corner is at (0, 0).
+
+    .. code-block::
+
+        radius = _calc_enclosing_circle_radius(circle_center, rectangle_size)
+    '''
+    w, h = rectangle_size
+    x, y = circle_center
+    return hypot(max(abs(x), abs(w - x)), max(abs(y), abs(h - y)))
+
+
+@asynccontextmanager
+async def iris_transition(target: WindowBase=Window, *, duration=1, out_curve='in_cubic', in_curve='out_cubic',
+                          color: Sequence[float]=colormap['white'], circle_center: Sequence[float]=None,
+                          overlay: VertexInstruction=None):
+    '''
+    .. versionadded:: 0.9.0
+    '''
+    if not isinstance(target, WindowBase):
+        raise TypeError(f"'target' must be a WindowBase instance, not {type(target).__name__}")
+    half_d = duration / 2
+    canvas = target.canvas
+    if circle_center is None:
+        circle_center = target.center
+    if overlay is None:
+        overlay = Rectangle(size=target.size)
+    radius = _calc_enclosing_circle_radius(circle_center, target.size)
+    diameter = radius * 2.
+    ellipse_start_pos = (circle_center[0] - radius, circle_center[1] - radius)
+    ellipse_start_size = (diameter, diameter)
+    ig = InstructionGroup()
+    ig_add = ig.add
+    ig_add(StencilPush())
+    ig_add(inner_ig := InstructionGroup())
+    inner_ig.add(ellipse := Ellipse(pos=ellipse_start_pos, size=ellipse_start_size))
+    ig_add(overlay)
+    ig_add(StencilUse())
+    ig_add(Color(*color))
+    ig_add(overlay)
+    ig_add(StencilUnUse())
+    ig_add(overlay)
+    ig_add(ellipse)
+    ig_add(StencilPop())
+
+    canvas.add(ig)
+    try:
+        await anim_attrs_abbr(ellipse, d=half_d, t=out_curve, pos=circle_center, size=(0, 0))
+        # Setting the ellipse size to (0, 0) isn't enough to nullify the stencil effect for some reason,
+        # so we remove it from the canvas and re-add it later.
+        inner_ig.remove(ellipse)
+        yield
+        inner_ig.add(ellipse)
+        await anim_attrs_abbr(ellipse, d=half_d, t=in_curve, pos=ellipse_start_pos, size=ellipse_start_size)
+    finally:
+        canvas.remove(ig)


### PR DESCRIPTION
https://youtu.be/qehA3oIMXZo

### Concern

- The name `transition` might be too genetic and may need to be more specific, such as `screen_transition` or `widget_transition`
- Leave `asynckivy.fade_transition` or merge it somehow