### PR TITLE
Make `transform` not create a `canvas.before` when `use_outer_canvas` is set to False

### DIFF
--- a/src/asynckivy/_etc.py
+++ b/src/asynckivy/_etc.py
@@ -73,12 +73,12 @@ def transform(widget, *, use_outer_canvas=False) -> Iterator[InstructionGroup]:
         push_mat_idx = 0
         ig_idx = 1
     else:
-        c.before  # ensure 'canvas.before' exists
-
-        # Index starts from 1 because 'canvas.before' is sitting at index 0 and we usually want it to remain first.
-        # See https://github.com/kivy/kivy/issues/7945 for details.
-        push_mat_idx = 1
-        ig_idx = 2
+        if c.has_before:
+            push_mat_idx = 1
+            ig_idx = 2
+        else:
+            push_mat_idx = 0
+            ig_idx = 1
         before = after = c
 
     push_mat = PushMatrix()

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -42,32 +42,20 @@ def test_use_outer_canvas(widget, has_before, has_after):
 
 
 @pytest.mark.parametrize('has_before', (True, False, ))
-def test_use_inner_canvas__has_after(widget, has_before):
-    from asynckivy import transform
-    c = widget.canvas
-    c.after
-    if has_before: c.before
-    with transform(widget, use_outer_canvas=False):
-        assert c.has_before
-        assert c.has_after
-        assert list_children(c) == ['CanvasBase', 'PushMatrix', 'InstructionGroup', 'Color', 'PopMatrix', 'CanvasBase', ]
-        assert list_children(c.before) == []
-        assert list_children(c.after) == []
-    assert list_children(c) == ['CanvasBase', 'Color', 'CanvasBase', ]
-    assert list_children(c.before) == []
-    assert list_children(c.after) == []
-
-
-@pytest.mark.parametrize('has_before', (True, False, ))
-def test_use_inner_canvas__no_after(widget, has_before):
+@pytest.mark.parametrize('has_after', (True, False, ))
+def test_use_inner_canvas(widget, has_before, has_after):
     from asynckivy import transform
     c = widget.canvas
     if has_before: c.before
+    if has_after: c.after
     with transform(widget, use_outer_canvas=False):
-        assert c.has_before
-        assert not c.has_after
-        assert list_children(c) == ['CanvasBase', 'PushMatrix', 'InstructionGroup', 'Color', 'PopMatrix', ]
-        assert list_children(c.before) == []
-    assert not c.has_after
-    assert list_children(c) == ['CanvasBase', 'Color', ]
-    assert list_children(c.before) == []
+        expect = ['PushMatrix', 'InstructionGroup', 'Color', 'PopMatrix', ]
+        if has_before:
+            assert list_children(c.before) == []
+            expect.insert(0, 'CanvasBase')
+        if has_after:
+            assert list_children(c.after) == []
+            expect.append('CanvasBase')
+        assert list_children(c) == expect
+    assert c.has_before is has_before
+    assert c.has_after is has_after


### PR DESCRIPTION
外側のcanvasを使わないでと指示した時でさえ `canvas.before` が作られてしまうのは直感に反すると思うので作らないように変更