### PR TITLE
Deprecate `anim_with_xxx` APIs except `anim_with_ratio`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asynckivy"
-version = "0.9.0"
+version = "0.9.1.dev0"
 description = "Async library for Kivy"
 authors = ["Nattōsai Mitō <flow4re2c@gmail.com>"]
 license = "MIT"

--- a/src/asynckivy/_anim_with_xxx.py
+++ b/src/asynckivy/_anim_with_xxx.py
@@ -28,6 +28,9 @@ async def anim_with_dt(*, step=0):
                 break
 
     .. versionadded:: 0.6.1
+
+    .. deprecated:: 0.9.1
+        This will be removed in version 0.11.0. Use :func:`asynckivy.sleep_freq` instead.
     '''
     async with repeat_sleeping(step=step) as sleep:
         while True:
@@ -53,6 +56,9 @@ async def anim_with_et(*, step=0):
             print(et)
 
     .. versionadded:: 0.6.1
+
+    .. deprecated:: 0.9.1
+        This will be removed in version 0.11.0. Use :func:`asynckivy.sleep_freq` instead.
     '''
     et = 0.
     async with repeat_sleeping(step=step) as sleep:
@@ -71,6 +77,9 @@ async def anim_with_dt_et(*, step=0):
             ...
 
     .. versionadded:: 0.6.1
+
+    .. deprecated:: 0.9.1
+        This will be removed in version 0.11.0. Use :func:`asynckivy.sleep_freq` instead.
     '''
     et = 0.
     async with repeat_sleeping(step=step) as sleep:
@@ -138,6 +147,9 @@ async def anim_with_dt_et_ratio(*, base, step=0):
     .. versionchanged:: 0.7.0
         The ``duration`` parameter was replaced with ``base``.
         The loop no longer ends on its own.
+
+    .. deprecated:: 0.9.1
+        This will be removed in version 0.11.0. Use :func:`asynckivy.sleep_freq` instead.
     '''
     async with repeat_sleeping(step=step) as sleep:
         et = 0.


### PR DESCRIPTION
`anim_with_xxx`系のAPIはasyncジェネレータを作るという短所の割に大した仕事をしていないのでいずれ削除する。ただし一番需要が高そうな `anim_with_ratio` は残す。