### PR TITLE
Add a safer version of  `rest_of_touch_events`

### DIFF
--- a/src/asynckivy/__init__.py
+++ b/src/asynckivy/__init__.py
@@ -16,6 +16,7 @@ __all__ = (
     'n_frames',
     'repeat_sleeping',
     'rest_of_touch_events',
+    'rest_of_touch_events_cm',
     'run_in_executor',
     'run_in_thread',
     'sleep',
@@ -32,7 +33,7 @@ __all__ = (
 
 from asyncgui import *
 from ._sleep import sleep, sleep_free, repeat_sleeping, move_on_after, n_frames, sleep_freq
-from ._event import event, event_freq, suppress_event, rest_of_touch_events
+from ._event import event, event_freq, suppress_event, rest_of_touch_events, rest_of_touch_events_cm
 from ._anim_with_xxx import anim_with_dt, anim_with_et, anim_with_ratio, anim_with_dt_et, anim_with_dt_et_ratio
 from ._anim_attrs import anim_attrs, anim_attrs_abbr
 from ._interpolate import interpolate, interpolate_seq, fade_transition


### PR DESCRIPTION
```python
async for __ rest_of_touch_events(widget, touch):
    print("on_touch_move")
print("on_touch_up")
```

is equivalent to

```python
async with rest_of_touch_events_cm(widget, touch) as on_touch_move:
    while True:
        await on_touch_move()
        print("on_touch_move")
print("on_touch_up")
```

The latter is more verbose, but in return, it's safe even when Kivy is running in async mode.
